### PR TITLE
Give the ability to set groupName on Sitemap Factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "league/flysystem": "^3"
+        "league/flysystem": "^1.1 || ^3"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "league/flysystem": "1.0.*"
+        "league/flysystem": "^1.1"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "league/flysystem": "^1.1"
+        "league/flysystem": "^3"
     },
     "autoload": {
         "files": [

--- a/src/SitemapFactory.php
+++ b/src/SitemapFactory.php
@@ -5,13 +5,13 @@ namespace Tackk\Cartographer;
 use ArrayObject;
 use DateTime;
 use Iterator;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 use RuntimeException;
 
 class SitemapFactory
 {
     /**
-     * @var FilesystemInterface
+     * @var FilesystemOperator
      */
     protected $filesystem = null;
 
@@ -31,9 +31,9 @@ class SitemapFactory
     protected $filesCreated = [];
 
     /**
-     * @param FilesystemInterface $filesystem
+     * @param FilesystemOperator $filesystem
      */
-    public function __construct(FilesystemInterface $filesystem)
+    public function __construct(FilesystemOperator $filesystem)
     {
         $this->filesystem = $filesystem;
         $this->groupName = $this->randomHash();
@@ -41,7 +41,7 @@ class SitemapFactory
 
     /**
      * Gets the Filesystem.
-     * @return FilesystemInterface
+     * @return FilesystemOperator
      */
     public function getFilesystem()
     {

--- a/src/SitemapFactory.php
+++ b/src/SitemapFactory.php
@@ -21,6 +21,11 @@ class SitemapFactory
     protected $baseUrl = '';
 
     /**
+     * @var string
+     */
+    protected $groupName = '';
+
+    /**
      * @var array
      */
     protected $filesCreated = [];
@@ -31,6 +36,7 @@ class SitemapFactory
     public function __construct(FilesystemInterface $filesystem)
     {
         $this->filesystem = $filesystem;
+        $this->groupName = $this->randomHash();
     }
 
     /**
@@ -65,6 +71,28 @@ class SitemapFactory
     }
 
     /**
+     * Sets the Group Name for sitemap file names.
+     *
+     * @param  string $groupName
+     * @return $this
+     */
+    public function setGroupName($groupName)
+    {
+        $this->groupName = $groupName;
+
+        return $this;
+    }
+
+    /**
+     * Gets the Group Name for sitemap file names.
+     * @return string
+     */
+    public function getGroupName()
+    {
+        return $this->groupName;
+    }
+
+    /**
      * Gets the array of files created.
      * @return array
      */
@@ -81,7 +109,7 @@ class SitemapFactory
      */
     public function createSitemap(Iterator $iterator)
     {
-        $groupName = $this->randomHash();
+        $groupName = $this->groupName;
         $paths = new ArrayObject();
         $sitemap = new Sitemap();
         foreach ($iterator as $entry) {
@@ -109,7 +137,7 @@ class SitemapFactory
      */
     public function createSitemapIndex(Iterator $sitemaps)
     {
-        $groupName = $this->randomHash();
+        $groupName = $this->groupName;
         $sitemapIndexes = new ArrayObject();
         $sitemapIndex = new SitemapIndex();
         $lastmod = date(DateTime::W3C);


### PR DESCRIPTION
This creates predictable filenames so they can be updated without having to rename or resubmit the sitemaps.
