### PR TITLE
add support for google sitemap images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Code Coverage](https://scrutinizer-ci.com/g/tackk/cartographer/badges/coverage.png?s=5547a47fb7e014a26cc4b43f69832f82b673d8ba)](https://scrutinizer-ci.com/g/tackk/cartographer/)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/tackk/cartographer/badges/quality-score.png?s=47b9d98507fa3ea5be94ef3656a3de5a5bff662d)](https://scrutinizer-ci.com/g/tackk/cartographer/)
 
+----
+
 A sitemap generation tool for PHP following the [Sitemap Protocol v0.9](http://www.sitemaps.org/protocol.html).
 
 Cartographer can handle Sitemaps of any size.  When generating sitemaps with more than 50,000
@@ -169,6 +171,53 @@ $urls = get_url_iterator();
 $mainSitemap = $sitemapFactory->createSitemap($urls);
 
 ```
+
+
+### Google image extension
+
+With simple sitemap:
+
+```php
+<?php
+
+use Tackk\Cartographer\GoogleSitemap;
+use Tackk\Cartographer\ChangeFrequency;
+
+$sitemap = new Tackk\Cartographer\GoogleSitemap();
+$sitemap->add('http://foo.com', '2005-01-02', ChangeFrequency::WEEKLY, 1.0);
+// Adds an image for the previous url
+$sitemap->addImage('http://foo.com/bar.jpg', 'image title', 'image caption', 'geo location', 'license');
+
+// Write it to a file
+file_put_contents('sitemap.xml', (string) $sitemap);
+```
+
+
+With sitemap factory the iterator should return an array of url that also contains an 'images' key with all images of the url.
+
+```php
+<?php
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local as LocalAdapter;
+
+$adapter = new LocalAdapter(__DIR__.'/sitemaps');
+$filesystem = new Filesystem($adapter);
+$sitemapFactory = new Tackk\Cartographer\GoogleSitemapFactory($filesystem);
+
+// Create an Iterator of your URLs somehow.
+$urls = get_url_iterator();
+
+// Url iterator items format:
+// ['url' => 'http://foo.com', 'images' => [
+//    ['loc' => 'http://foo.com/bar.jpg']
+// ]
+
+// Returns the URL to the main Sitemap/Index file
+$mainSitemap = $sitemapFactory->createSitemap($urls);
+
+```
+
 
 ### Return Value
 

--- a/src/AbstractSitemap.php
+++ b/src/AbstractSitemap.php
@@ -7,11 +7,7 @@ use DateTimeZone;
 use DOMDocument;
 use DOMElement;
 use InvalidArgumentException;
-use RuntimeException;
 
-class MaxUrlCountExceededException extends RuntimeException
-{
-}
 
 
 abstract class AbstractSitemap
@@ -29,6 +25,11 @@ abstract class AbstractSitemap
      * @return string
      */
     abstract protected function getNodeName();
+
+    protected function getNamespaceExtensions()
+    {
+        return [];
+    }
 
     /**
      * @var string
@@ -65,6 +66,8 @@ abstract class AbstractSitemap
      */
     protected $urlCount = 0;
 
+    private $lastUrlNode = null;
+
     /**
      * Sets up the sitemap XML document and urlset node.
      */
@@ -72,6 +75,10 @@ abstract class AbstractSitemap
     {
         $this->document = new DOMDocument($this->xmlVersion, $this->xmlEncoding);
         $this->rootNode = $this->document->createElementNS($this->xmlNamespaceUri, $this->getRootNodeName());
+
+        foreach ($this->getNamespaceExtensions() as $qualifiedName => $value) {
+            $this->rootNode->setAttributeNS('http://www.w3.org/2000/xmlns/', $qualifiedName, $value);
+        }
 
         // Make the output Pretty
         $this->document->formatOutput = true;
@@ -154,7 +161,17 @@ abstract class AbstractSitemap
         $this->rootNode->appendChild($node);
         $this->urlCount++;
 
+        $this->lastUrlNode = $node;
+
         return $this;
+    }
+
+    /**
+     * @return DOMElement|null
+     */
+    public function getLastUrlNode()
+    {
+        return $this->lastUrlNode;
     }
 
     /**

--- a/src/GoogleSitemap.php
+++ b/src/GoogleSitemap.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @license see LICENSE
+ */
+
+namespace Tackk\Cartographer;
+
+
+class GoogleSitemap extends Sitemap
+{
+
+    const IMAGE_EXTENSION_URI = 'http://www.google.com/schemas/sitemap-image/1.1';
+
+    protected function getNamespaceExtensions()
+    {
+        $extensions = parent::getNamespaceExtensions();
+        $extensions['xmlns:image'] = self::IMAGE_EXTENSION_URI;
+
+        return $extensions;
+    }
+
+    /**
+     * Adds the URL to the urlset.
+     * @param  string $loc
+     * @param  string|int $lastmod
+     * @param  string $changefreq
+     * @param  float $priority
+     * @param  array|null $images
+     * @return $this
+     */
+    public function add($loc, $lastmod = null, $changefreq = null, $priority = null, array $images = null)
+    {
+        parent::add($loc, $lastmod, $changefreq, $priority);
+
+        if ($images) {
+            foreach ($images as $imageData) {
+                $this->addImage($imageData);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param $imageData
+     * @return $this
+     * @throws \Exception
+     */
+    public function addImage ($loc, $title = null, $caption = null, $geo_location = null, $license = null)
+    {
+        $this->hasImageExtension = true;
+        $node = $this->getLastUrlNode();
+
+        if (!$node) {
+            throw new \Exception('Cannot add image when no url was already added');
+        }
+
+        $imageNode = $this->document->createElementNS(self::IMAGE_EXTENSION_URI, 'image');
+
+        $imageData = compact('loc', 'title', 'caption', 'geo_location', 'license');
+
+        foreach ($imageData as $key => $value) {
+            if (is_null($value)) {
+                continue;
+            }
+
+            $imageNode->appendChild($this->document->createElementNS(self::IMAGE_EXTENSION_URI, $key, $value));
+        }
+
+        $node->appendChild($imageNode);
+
+        return $this;
+    }
+}

--- a/src/GoogleSitemapFactory.php
+++ b/src/GoogleSitemapFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tackk\Cartographer;
+
+use ArrayObject;
+use DateTime;
+use Iterator;
+use League\Flysystem\FilesystemInterface;
+use RuntimeException;
+
+class GoogleSitemapFactory extends SitemapFactory
+{
+
+    /**
+     * @return GoogleSitemap
+     */
+    protected function instantiateNewSitemap()
+    {
+        return new GoogleSitemap();
+    }
+
+    protected function addEntry($entry, AbstractSitemap $sitemap)
+    {
+        if (!$sitemap instanceof GoogleSitemap) {
+            throw new \Exception('Bad sitemap type. Must be a google site map instance');
+        }
+
+        parent::addEntry($entry, $sitemap);
+
+        $images = get_property($entry, 'images');
+
+        if ($images) {
+            foreach ($images as $image) {
+
+                $loc        = get_property($image, 'loc');
+                $title      = get_property($image, 'title');
+                $caption    = get_property($image, 'caption');
+                $geo_location = get_property($image, 'geo_location');
+                $license    = get_property($image, 'license');
+
+                $sitemap->addImage($loc, $title, $caption, $geo_location, $license);
+            }
+        }
+
+
+    }
+
+
+
+}

--- a/src/MaxUrlCountExceededException.php
+++ b/src/MaxUrlCountExceededException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tackk\Cartographer;
+
+use RuntimeException;
+
+class MaxUrlCountExceededException extends RuntimeException
+{
+}

--- a/src/SitemapFactory.php
+++ b/src/SitemapFactory.php
@@ -74,6 +74,20 @@ class SitemapFactory
     }
 
     /**
+     * @return AbstractSitemap
+     */
+    protected function instantiateNewSitemap()
+    {
+        return new Sitemap();
+    }
+
+    protected function addEntry($entry, Sitemap $sitemap)
+    {
+        list($url, $lastmod, $changefreq, $priority) = $this->parseEntry($entry);
+        $sitemap->add($url, $lastmod, $changefreq, $priority);
+    }
+
+    /**
      * Generates the sitemap(s) using the iterator previously set.
      * @param \Iterator $iterator
      * @throws \RuntimeException
@@ -83,15 +97,14 @@ class SitemapFactory
     {
         $groupName = $this->randomHash();
         $paths = new ArrayObject();
-        $sitemap = new Sitemap();
+        $sitemap = $this->instantiateNewSitemap();
         foreach ($iterator as $entry) {
             if ($sitemap->hasMaxUrlCount()) {
                 $paths->append($this->writeSitemap($groupName, $sitemap));
-                $sitemap = new Sitemap();
+                $sitemap = $this->instantiateNewSitemap();
             }
 
-            list($url, $lastmod, $changefreq, $priority) = $this->parseEntry($entry);
-            $sitemap->add($url, $lastmod, $changefreq, $priority);
+            $this->addEntry($entry, $sitemap);
         }
         $paths->append($this->writeSitemap($groupName, $sitemap));
 

--- a/tests/GoogleSitemapFactoryTest.php
+++ b/tests/GoogleSitemapFactoryTest.php
@@ -1,0 +1,126 @@
+<?php
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local as LocalAdapter;
+
+class GoogleSitemapFactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Tackk\Cartographer\SitemapFactory
+     */
+    protected $factory;
+
+    /**
+     * @var League\Flysystem\Filesystem
+     */
+    protected $filesystem;
+
+    public function setUp()
+    {
+        $adapter = new LocalAdapter(__DIR__.'/storage/sitemaps');
+        $this->filesystem = new Filesystem($adapter);
+        $this->factory = new Tackk\Cartographer\GoogleSitemapFactory($this->filesystem);
+    }
+
+    public function testCanInstantiate()
+    {
+        $this->assertInstanceOf(\Tackk\Cartographer\GoogleSitemapFactory::class, $this->factory);
+    }
+
+    public function testGetFilesystem()
+    {
+        $this->assertInstanceOf(\League\Flysystem\FilesystemInterface::class, $this->factory->getFilesystem());
+    }
+
+    public function testSetBaseUrl()
+    {
+        $this->factory->setBaseUrl('foo/');
+        $this->assertAttributeEquals('foo', 'baseUrl', $this->factory);
+
+        $this->factory->setBaseUrl('foo');
+        $this->assertAttributeEquals('foo', 'baseUrl', $this->factory);
+    }
+
+    public function testGetBaseUrl()
+    {
+        $class = new ReflectionClass($this->factory);
+        $baseUrl = $class->getProperty('baseUrl');
+        $baseUrl->setAccessible(true);
+        $baseUrl->setValue($this->factory, 'foo');
+
+        $this->assertEquals('foo', $this->factory->getBaseUrl());
+    }
+
+    public function testGetFileCreated()
+    {
+        $class = new ReflectionClass($this->factory);
+        $filesCreated = $class->getProperty('filesCreated');
+        $filesCreated->setAccessible(true);
+        $filesCreated->setValue($this->factory, ['foo.txt']);
+
+        $this->assertEquals(['foo.txt'], $this->factory->getFilesCreated());
+    }
+
+    public function testCreateRequiresIterator()
+    {
+        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->factory->createSitemap();
+    }
+
+    public function testCanCreateSmallSitemap()
+    {
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>http://foo.com/1</loc>
+    <image:image>
+      <image:loc>http://foo.com/1.jpg</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>http://foo.com/2</loc>
+    <image:image>
+      <image:loc>http://foo.com/2.jpg</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>http://foo.com/3</loc>
+    <image:image>
+      <image:loc>http://foo.com/3.jpg</image:loc>
+    </image:image>
+  </url>
+</urlset>
+
+XML;
+        $urls = [];
+        for ($i = 1; $i <= 3; $i++) {
+            $urls[] = ['url' => 'http://foo.com/'.$i, 'images' => [['loc' => 'http://foo.com/' . $i . '.jpg']]];
+        }
+        $path = $this->factory->createSitemap(new ArrayIterator($urls));
+
+        $actual = $this->filesystem->read($path);
+        $this->filesystem->delete($path);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testLargeSitemapCreatesIndex()
+    {
+        $urls = [];
+        for ($i = 1; $i <= 50002; $i++) {
+            $urls[] = ['url' => 'http://foo.com/'.$i];
+        }
+        $path = $this->factory->createSitemap(new ArrayIterator($urls));
+        $this->assertTrue($this->filesystem->has($path));
+
+        foreach ($this->factory->getFilesCreated() as $file) {
+            $this->assertTrue($this->filesystem->has($file));
+            $this->filesystem->delete($file);
+        }
+    }
+
+    public function testUrlMustBePresent()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Url is missing or not accessible.');
+        $this->factory->createSitemap(new ArrayIterator([[]]));
+    }
+}

--- a/tests/GoogleSitemapTest.php
+++ b/tests/GoogleSitemapTest.php
@@ -1,0 +1,52 @@
+<?php
+use Tackk\Cartographer\Sitemap;
+use Tackk\Cartographer\ChangeFrequency;
+use Tackk\Cartographer\GoogleSitemap;
+
+class GoogleSitemapTest extends PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>http://foo.com</loc>
+    <lastmod>2005-01-02T00:00:00+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>http://foo.com/about</loc>
+    <lastmod>2005-01-01T00:00:00+00:00</lastmod>
+    <image:image>
+      <image:loc>http://foo.com/foo.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>http://foo.com/bar.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>http://foo.com/bar</loc>
+    <lastmod>2005-01-01T00:00:00+00:00</lastmod>
+    <image:image>
+      <image:loc>http://foo.com/baz.jpg</image:loc>
+      <image:title>some title</image:title>
+      <image:caption>some caption</image:caption>
+      <image:geo_location>somewhere</image:geo_location>
+      <image:license>http://foo.com/license</image:license>
+    </image:image>
+  </url>
+</urlset>
+
+XML;
+        $sitemap = new GoogleSitemap();
+        $sitemap->add('http://foo.com', '2005-01-02', ChangeFrequency::WEEKLY, 1.0);
+        $sitemap->add('http://foo.com/about', '2005-01-01');
+        $sitemap->addImage('http://foo.com/foo.png');
+        $sitemap->addImage('http://foo.com/bar.png');
+        $sitemap->add('http://foo.com/bar', '2005-01-01');
+        $sitemap->addImage('http://foo.com/baz.jpg', 'some title', 'some caption', 'somewhere', 'http://foo.com/license');
+        $this->assertEquals($expected, $sitemap->toString());
+    }
+}


### PR DESCRIPTION
This PR adds a a new GoogleSitemap class that allows to create images to urls as specified by google (https://support.google.com/webmasters/answer/178636?hl=en)